### PR TITLE
Added support for XML "nillable" when using SOAP overload extension

### DIFF
--- a/SOAP/WSDL.php
+++ b/SOAP/WSDL.php
@@ -514,14 +514,14 @@ class SOAP_WSDL extends SOAP_Base
             $args .= ', ';
         }
         $args .= '$' . $argname;
-        if($nillable) {
+        if ($nillable) {
             $args .= ' = null';
             $nillableArgs[] = $argname;
         }
         if (!$this->_validateString($argname)) {
             return;
         }
-        if(!$nillable) {
+        if (!$nillable) {
             if ($argarray) {
                 $argarray .= ', ';
             }
@@ -705,7 +705,7 @@ class SOAP_WSDL extends SOAP_Base
                             if (isset($el['elements'])) {
                                 foreach ($el['elements'] as $elname => $elattrs) {
                                     $elname = $this->_sanitize($elname);
-                                    if((isset($elattrs['nillable']) && $elattrs['nillable'])
+                                    if ((isset($elattrs['nillable']) && $elattrs['nillable'])
                                     || (isset($elattrs['minOccurs']) && $elattrs['minOccurs'] == 0)) {
                                         // If you encounter one nillable, all subsequent
                                         // arguments must default to null
@@ -722,7 +722,7 @@ class SOAP_WSDL extends SOAP_Base
                             if ($el['complex'] && $argarray) {
                                 $wrapname = '{' . $this->namespaces[$_argtype['namespace']].'}' . $el['name'];
                                 $comments .= "        \$v = array($argarray);\n";
-                                if($usingNillables && !empty($nillableArgs)) {
+                                if ($usingNillables && !empty($nillableArgs)) {
                                     foreach($nillableArgs as $nillableArg) {
                                         $comments .= "        isset(\$$nillableArg) && \$v['$nillableArg'] = \$$nillableArg;\n";
                                     }


### PR DESCRIPTION
Mainly this means that the eval'd class method signatures have arguments with default values of NULL as defined by the WSDL so you can call a method like $Client->[method name]([arg1], [arg2] = NULL) and omit arg2.

Currently this is not possible; if your WSDL specifies an arg to a method as nillable or minCount = 0, the generated PHP method signature code by SOAP_WSDL is such that you must provide all arguments to the method when calling it via overload extension. Also, if you pass NULL for an argument, it will still show up as empty in the generated request XML when really the nillable argument should be omitted entirely (and is with this patch if you leave the argument as NULL).
